### PR TITLE
v0.2.0 - split server/client types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 - The `RtcClient` and `RtcServer` system parameters (prev. `NetworkReader`/`NetworkWriter`) have new methods:
   - `clear()` to clear all incoming messages in the buffer.
-  - `iter()` to read all messages without consuming them.
 
 ### changed
 
@@ -20,6 +19,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
   - `RtcState` has changed to `RtcClientState` or `RtcServerState`, depending on the feature.
   - `RtcStatus` has changed to `RtcClientStatus` or `RtcServerStatus`, depending on the feature.
   - `NetworkReader`/`NetworkWriter` have been both merged and changed to `RtcClient` or `RtcServer` respectively.
+  - `RtcClient.read()` (previously `NetworkReader`) now returns a `Vec<_>` rather than a `Drain<'_, _>`.
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,24 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
+## 0.2.0
+
+### added
+
+- The `RtcClient` and `RtcServer` system parameters (prev. `NetworkReader`/`NetworkWriter`) have new methods:
+  - `clear()` to clear all incoming messages in the buffer.
+  - `iter()` to read all messages without consuming them.
+
+### changed
+
+- To fix name conflicts with the `server` and `client` feature, the respective types have changed names.
+  - `RtcState` has changed to `RtcClientState` or `RtcServerState`, depending on the feature.
+  - `RtcStatus` has changed to `RtcClientStatus` or `RtcServerStatus`, depending on the feature.
+  - `NetworkReader`/`NetworkWriter` have been both merged and changed to `RtcClient` or `RtcServer` respectively.
+
 ## 0.1.1
+
+### fixes
 
 - Fixed blank README on crates.io
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.1"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 description = "A client-server library designed over WebRTC for Bevy"
 repository = "https://github.com/loopystudios/bevy_rtc"

--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ pub enum MyPacket {
     ```rust
     .add_systems(
         Update,
-        |mut reader: NetworkReader<MyPacket>, mut writer: NetworkWriter<MyPacket>| {
-            for (peer_id, packet) in reader.read() {
+        |mut server: RtcServer<MyPacket>| {
+            for (peer_id, packet) in server.read() {
                 if let MyPacket::Ping = packet {
-                    writer.reliable_to_peer(peer_id, MyPacket::Pong);
+                    server.reliable_to_peer(peer_id, MyPacket::Pong);
                 }
             }
         })
@@ -168,8 +168,8 @@ pub enum MyPacket {
     .add_systems(
         Update,
         {
-            |mut writer: NetworkWriter<PingPayload>| {
-                writer.reliable_to_host(PingPayload::Ping);
+            |mut client: RtcClient<PingPayload>| {
+                client.reliable_to_host(PingPayload::Ping);
             }
         }
         .run_if(
@@ -179,8 +179,8 @@ pub enum MyPacket {
             ),
         ),
     )
-    .add_systems(Update, |mut reader: NetworkReader<PingPayload>| {
-        for payload in reader.read() {
+    .add_systems(Update, |mut client: RtcClient<PingPayload>| {
+        for payload in client.read() {
             if let PingPayload::Pong = payload {
                 info!("..Received pong!");
             }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Run the [demos](#demos) and [instructions](#instructions).
 
 | bevy  |  bevy_rtc   |
 |-------|-------------|
-| 0.13  | 0.1, main   |
+| 0.13  | 0.1-0.2, main   |
 | < 0.13| unsupported |
 
 ## Cargo features

--- a/bevy_rtc/src/client/mod.rs
+++ b/bevy_rtc/src/client/mod.rs
@@ -8,5 +8,5 @@ mod systems;
 pub use events::{ConnectionRequest, RtcClientEvent};
 pub use plugin::RtcClientPlugin;
 pub use router::AddProtocolExt;
-pub use state::{RtcClientStatus, RtcState};
-pub use system_params::{NetworkReader, NetworkWriter};
+pub use state::{RtcClientState, RtcClientStatus};
+pub use system_params::RtcClient;

--- a/bevy_rtc/src/client/plugin.rs
+++ b/bevy_rtc/src/client/plugin.rs
@@ -1,5 +1,5 @@
 use super::{
-    systems, AddProtocolExt, ConnectionRequest, RtcClientEvent, RtcClientStatus, RtcState,
+    systems, AddProtocolExt, ConnectionRequest, RtcClientEvent, RtcClientState, RtcClientStatus,
 };
 use crate::{
     events::SocketRecvEvent,
@@ -15,7 +15,7 @@ pub struct RtcClientPlugin;
 impl Plugin for RtcClientPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<SocketRecvEvent>()
-            .insert_resource(RtcState::default())
+            .insert_resource(RtcClientState::default())
             .add_bounded_protocol::<LatencyTracerPayload>(2)
             .init_state::<RtcClientStatus>()
             .add_event::<ConnectionRequest>()

--- a/bevy_rtc/src/client/router/send.rs
+++ b/bevy_rtc/src/client/router/send.rs
@@ -1,5 +1,5 @@
 use crate::{
-    client::state::RtcState,
+    client::state::RtcClientState,
     protocol::Payload,
     socket::{RtcSocket, RELIABLE_CHANNEL_INDEX, UNRELIABLE_CHANNEL_INDEX},
 };
@@ -22,7 +22,7 @@ impl<M: Payload> OutgoingMessages<M> {
     pub(crate) fn send_payloads(
         mut queue: ResMut<Self>,
         mut socket: ResMut<RtcSocket>,
-        state: Res<RtcState>,
+        state: Res<RtcClientState>,
     ) {
         if let Some(host) = state.host_id {
             // Client is sending

--- a/bevy_rtc/src/client/state.rs
+++ b/bevy_rtc/src/client/state.rs
@@ -15,7 +15,7 @@ pub enum RtcClientStatus {
 }
 
 #[derive(Resource, Default)]
-pub struct RtcState {
+pub struct RtcClientState {
     /// The socket address, used for connecting/reconnecting
     pub addr: Option<String>,
     /// The ID of the host

--- a/bevy_rtc/src/client/system_params.rs
+++ b/bevy_rtc/src/client/system_params.rs
@@ -9,7 +9,7 @@ pub struct RtcClient<'w, M: Payload> {
 }
 
 impl<'w, M: Payload> RtcClient<'w, M> {
-    /// Returns the capacity of this network reader.
+    /// Returns the capacity of incoming messages.
     pub fn capacity(&self) -> usize {
         self.incoming.bound
     }
@@ -24,19 +24,14 @@ impl<'w, M: Payload> RtcClient<'w, M> {
         self.incoming.messages.is_empty()
     }
 
-    /// Iterate over all messages in the buffer without consuming them.
-    pub fn iter(&mut self) -> impl Iterator<Item = &M> {
-        self.incoming.messages.iter()
-    }
-
     /// Clear all messages waiting in the buffer.
     pub fn clear(&mut self) {
         self.incoming.messages.clear()
     }
 
     /// Consumes all messages in the buffer and iterate on them.
-    pub fn read(&mut self) -> std::collections::vec_deque::Drain<'_, M> {
-        self.incoming.messages.drain(..)
+    pub fn read(&mut self) -> Vec<M> {
+        self.incoming.messages.drain(..).collect()
     }
 
     /// Send a payload to the host with reliability. The payload is created with

--- a/bevy_rtc/src/client/systems.rs
+++ b/bevy_rtc/src/client/systems.rs
@@ -157,13 +157,12 @@ pub fn read_latency_tracers(
     let peer_id = state.id.expect("expected peer id");
     let mut tracer = trace_query.single_mut();
 
-    let mut server_tracer = None;
     for payload in client.read() {
         if payload.from == peer_id {
             tracer.process(payload);
         } else if payload.from == host_id {
             // Server time payloads get sent right back to the server
-            server_tracer.replace(payload);
+            client.unreliable_to_host(payload);
         }
         // Process payloads we sent out
         else {
@@ -172,9 +171,6 @@ pub fn read_latency_tracers(
                 payload.from
             );
         }
-    }
-    if let Some(payload) = server_tracer.take() {
-        client.unreliable_to_host(payload);
     }
 }
 

--- a/bevy_rtc/src/server/mod.rs
+++ b/bevy_rtc/src/server/mod.rs
@@ -8,5 +8,5 @@ mod systems;
 pub use events::RtcServerEvent;
 pub use plugin::RtcServerPlugin;
 pub use router::AddProtocolExt;
-pub use state::{RtcServerStatus, RtcState};
-pub use system_params::{NetworkReader, NetworkWriter};
+pub use state::{RtcServerState, RtcServerStatus};
+pub use system_params::RtcServer;

--- a/bevy_rtc/src/server/plugin.rs
+++ b/bevy_rtc/src/server/plugin.rs
@@ -7,7 +7,7 @@ use bevy::{prelude::*, time::common_conditions::on_timer};
 use instant::Duration;
 use std::net::Ipv4Addr;
 
-use super::{systems, AddProtocolExt, RtcServerEvent, RtcServerStatus, RtcState};
+use super::{systems, AddProtocolExt, RtcServerEvent, RtcServerState, RtcServerStatus};
 
 /// A plugin to serve a WebRTC server.
 pub struct RtcServerPlugin {
@@ -21,7 +21,9 @@ impl Plugin for RtcServerPlugin {
             .add_event::<RtcServerEvent>()
             .add_bounded_protocol::<LatencyTracerPayload>(2)
             .init_state::<RtcServerStatus>()
-            .insert_resource(RtcState::new((Ipv4Addr::UNSPECIFIED, self.port).into()))
+            .insert_resource(RtcServerState::new(
+                (Ipv4Addr::UNSPECIFIED, self.port).into(),
+            ))
             .add_systems(
                 Startup,
                 // We start a signaling server on localhost and the first peer

--- a/bevy_rtc/src/server/state.rs
+++ b/bevy_rtc/src/server/state.rs
@@ -18,7 +18,7 @@ pub enum RtcServerStatus {
 }
 
 #[derive(Resource)]
-pub struct RtcState {
+pub struct RtcServerState {
     /// The socket address bound
     pub addr: SocketAddr,
 
@@ -35,7 +35,7 @@ pub struct RtcState {
     pub(crate) smoothed_latencies: HashMap<PeerId, Option<Duration>>,
 }
 
-impl RtcState {
+impl RtcServerState {
     pub fn new(addr: SocketAddr) -> Self {
         Self {
             addr,

--- a/bevy_rtc/src/server/system_params.rs
+++ b/bevy_rtc/src/server/system_params.rs
@@ -37,18 +37,6 @@ impl<'w, M: Payload> RtcServer<'w, M> {
             })
     }
 
-    /// Iterate over all messages in the buffer without consuming them.
-    pub fn iter(&mut self) -> impl Iterator<Item = (&PeerId, &M)> {
-        self.incoming
-            .messages
-            .iter()
-            .fold(vec![], |mut v, (peer, payloads)| {
-                v.extend(payloads.iter().map(|p| (peer, p)));
-                v
-            })
-            .into_iter()
-    }
-
     /// Clear all messages waiting in the buffer.
     pub fn clear(&mut self) {
         self.incoming.messages.clear()

--- a/bevy_rtc/src/server/systems.rs
+++ b/bevy_rtc/src/server/systems.rs
@@ -3,7 +3,7 @@ use crate::{
     latency::{LatencyTracer, LatencyTracerPayload},
     socket::RtcSocket,
 };
-use bevy::{prelude::*, utils::hashbrown::HashMap};
+use bevy::prelude::*;
 use bevy_matchbox::{
     matchbox_signaling::{
         topologies::client_server::{ClientServer, ClientServerState},
@@ -144,7 +144,6 @@ pub fn read_latency_tracers(
     let host_id = state.id.expect("expected host id");
 
     // Handle payloads
-    let mut client_tracers = HashMap::new();
     for (from, payload) in server.read() {
         // 2 cases:
         // 1) We sent a tracer to the client, and are receiving it
@@ -156,14 +155,10 @@ pub fn read_latency_tracers(
             }
         } else if payload.from == from {
             // Case 2
-            client_tracers.insert(from, payload);
+            server.unreliable_to_peer(from, payload);
         } else {
             warn!("Invalid latency tracer from {from}: {payload:?}, ignoring");
         }
-    }
-
-    for (client, payload) in client_tracers.into_iter() {
-        server.unreliable_to_peer(client, payload);
     }
 }
 

--- a/demos/ping-client/src/main.rs
+++ b/demos/ping-client/src/main.rs
@@ -2,8 +2,7 @@ use std::time::Duration;
 
 use bevy::{log::LogPlugin, prelude::*, time::common_conditions::on_timer};
 use bevy_rtc::client::{
-    AddProtocolExt, ConnectionRequest, NetworkReader, NetworkWriter, RtcClientPlugin,
-    RtcClientStatus,
+    AddProtocolExt, ConnectionRequest, RtcClient, RtcClientPlugin, RtcClientStatus,
 };
 use protocol::PingPayload;
 
@@ -24,8 +23,8 @@ fn main() {
         .add_systems(
             Update,
             {
-                |mut writer: NetworkWriter<PingPayload>| {
-                    writer.reliable_to_host(PingPayload::Ping);
+                |mut client: RtcClient<PingPayload>| {
+                    client.reliable_to_host(PingPayload::Ping);
                     info!("Sent ping...")
                 }
             }
@@ -33,7 +32,7 @@ fn main() {
                 on_timer(Duration::from_secs(1)).and_then(in_state(RtcClientStatus::Connected)),
             ),
         )
-        .add_systems(Update, |mut reader: NetworkReader<PingPayload>| {
+        .add_systems(Update, |mut reader: RtcClient<PingPayload>| {
             for payload in reader.read() {
                 if let PingPayload::Pong = payload {
                     info!("...Received pong!");

--- a/demos/ping-server/src/main.rs
+++ b/demos/ping-server/src/main.rs
@@ -1,5 +1,5 @@
 use bevy::{log::LogPlugin, prelude::*};
-use bevy_rtc::server::{AddProtocolExt, NetworkReader, NetworkWriter, RtcServerPlugin};
+use bevy_rtc::server::{AddProtocolExt, RtcServer, RtcServerPlugin};
 use protocol::PingPayload;
 
 fn main() {
@@ -8,16 +8,13 @@ fn main() {
         .add_plugins(LogPlugin::default())
         .add_plugins(RtcServerPlugin { port: 3536 })
         .add_bounded_protocol::<PingPayload>(1)
-        .add_systems(
-            Update,
-            |mut reader: NetworkReader<PingPayload>, mut writer: NetworkWriter<PingPayload>| {
-                for (peer_id, packet) in reader.read() {
-                    if let PingPayload::Ping = packet {
-                        info!("Received ping! Sending pong...");
-                        writer.reliable_to_peer(peer_id, PingPayload::Pong);
-                    }
+        .add_systems(Update, |mut server: RtcServer<PingPayload>| {
+            for (peer_id, packet) in server.read() {
+                if let PingPayload::Ping = packet {
+                    info!("Received ping! Sending pong...");
+                    server.reliable_to_peer(peer_id, PingPayload::Pong);
                 }
-            },
-        )
+            }
+        })
         .run();
 }


### PR DESCRIPTION
This change is primarily motivated by Bevy's ecosystem standards - "features are additive".
<img width="1281" alt="image" src="https://github.com/loopystudios/bevy_rtc/assets/48108917/c2c09b68-0c6a-4bba-9489-a1e0a4362f6a">

If someone uses both the `server` and `client` feature in v0.1, they'd inherit two different types of `NetworkReader` and `NetworkWriter`, one for a client, one for a server.

The changes in this PR allow someone to use both features without name collision. The `NetworkReader` and `NetworkReader` have been combined into a single type, now respectively `RtcClient` or `RtcServer`. 

In addition, this PR also solves a thorny borrow issue.
Now that `NetworkReader` and `NetworkWriter` have been combined, the following was not possible on clients:
```rust
for .. in client.read() {
    client.reliable_to_host(..)
}
```

This is because `.read()` takes `&mut self` and so does `.reliable_to_host()`. (2 mutable borrows)

A minor change to address this was that the definition of `read()` changed on the client to return an owned `Vec<M>` instead of a `VecDeque<'_, M>`. The lifetime was problematic.